### PR TITLE
Remove deprecated top level constants

### DIFF
--- a/lib/ingenico/connect/sdk/api_resource.rb
+++ b/lib/ingenico/connect/sdk/api_resource.rb
@@ -16,8 +16,8 @@ module Ingenico::Connect::SDK
     #                     !{'version' => 'v1', 'merchantId' => '1234'}. The final url in this case will be
     #                     https://api-sandbox.globalcollect.com/v1/1234/payments.
     # client_meta_info::  JSON string containing the meta data for the client.
-    def initialize(arg, path_context, client_meta_info=FALSE)
-      if client_meta_info == FALSE
+    def initialize(arg, path_context, client_meta_info=false)
+      if client_meta_info == false
         if arg.nil?
           raise ArgumentError.new('parent is required')
         end
@@ -53,8 +53,8 @@ module Ingenico::Connect::SDK
       end
     end
 
-    def instantiate_uri(uri, path_context=FALSE)
-      if path_context == FALSE
+    def instantiate_uri(uri, path_context=false)
+      if path_context == false
         uri = replace_all(uri, @path_context)
         unless @parent.nil?
           uri = @parent.instantiate_uri(uri)

--- a/lib/ingenico/connect/sdk/declined_transaction_exception.rb
+++ b/lib/ingenico/connect/sdk/declined_transaction_exception.rb
@@ -5,8 +5,8 @@ module Ingenico::Connect::SDK
 
     # Create a new DeclinedTransactionException.
     # @see ApiException#initialize
-    def initialize(status_code, response_body, error_id, errors, message=FALSE)
-      if message == FALSE
+    def initialize(status_code, response_body, error_id, errors, message=false)
+      if message == false
         super(status_code, response_body, error_id, errors)
       else
         super(status_code, response_body, error_id, errors, message)

--- a/lib/ingenico/connect/sdk/not_found_exception.rb
+++ b/lib/ingenico/connect/sdk/not_found_exception.rb
@@ -4,7 +4,7 @@ module Ingenico::Connect::SDK
   # This error corresponds to a 404 HTTP response.
   class NotFoundException < RuntimeError
 
-    def initialize(cause, message=FALSE)
+    def initialize(cause, message=false)
       if message
         super(message)
       else

--- a/lib/ingenico/connect/sdk/param_request.rb
+++ b/lib/ingenico/connect/sdk/param_request.rb
@@ -17,13 +17,13 @@ module Ingenico::Connect::SDK
 
     private
 
-    def add_param(request_parameters, name, value, allow_collection = TRUE)
+    def add_param(request_parameters, name, value, allow_collection = true)
       if value.is_a?(String) || value.is_a?(Integer) || value.class == TrueClass ||
           value.class == FalseClass
         request_parameters.push(RequestParam.new(name, value.to_s))
       elsif allow_collection && value.class == Array
         value.each { |element|
-          add_param(request_parameters, name, element, FALSE)
+          add_param(request_parameters, name, element, false)
         }
       elsif !value.nil?
         raise ArgumentError.new("Unsupported request parameter type: #{value.class}")


### PR DESCRIPTION
TRUE, FALSE, and NIL were deprecated in ruby 2.4. Currently deprecation warnings show up in the console when using them.

They will be removed in a future ruby release (https://bugs.ruby-lang.org/issues/12574).